### PR TITLE
Updates to celun required for TDM

### DIFF
--- a/modules/hardware/cpus/rockchip.nix
+++ b/modules/hardware/cpus/rockchip.nix
@@ -1,8 +1,12 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkMerge mkOption types;
+  inherit (lib) any mkIf mkMerge mkOption types;
   cfg = config.hardware.cpus;
+  anyRockchip = any (x: x) [
+    cfg.rockchip-rk3399.enable
+    cfg.rockchip-rk3566.enable
+  ];
 in
 {
   options.hardware.cpus = {
@@ -10,6 +14,12 @@ in
       type = types.bool;
       default = false;
       description = "Enable when system is a Rockchip RK3399.";
+      internal = true;
+    };
+    rockchip-rk3566.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable when system is a Rockchip RK3566.";
       internal = true;
     };
   };
@@ -24,7 +34,18 @@ in
         pxefile_addr_r = "0x00600000";
         ramdisk_addr_r = "0x06000000";
       };
-
+    })
+    (lib.mkIf cfg.rockchip-rk3566.enable {
+      celun.system.system = "aarch64-linux";
+      wip.u-boot = {
+        enable = true;
+        fdt_addr_r     = "0x01f00000";
+        kernel_addr_r  = "0x02080000";
+        pxefile_addr_r = "0x00600000";
+        ramdisk_addr_r = "0x06000000";
+      };
+    })
+    (lib.mkIf anyRockchip {
       wip.kernel.structuredConfig =
         with lib.kernel;
         let

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -195,7 +195,13 @@ let
     echo
     echo "devtype = $devtype"
     echo "devnum = $devnum"
-    part list $devtype $devnum -bootable bootpart
+    if test -z "$bootpart"; then
+      if test -z "$distro_bootpart"; then
+        part list $devtype $devnum -bootable bootpart
+      else
+        bootpart=$distro_bootpart
+      fi
+    fi
     echo "bootpart = $bootpart"
 
     echo -n ' :: Auto-booting FIT image'

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -214,7 +214,7 @@ let
      && source $loadaddr:default-boot
   '');
 
-  partitionContent = pkgs.runCommandNoCC "${nameForDerivation}-boot" {
+  filesystemContent = pkgs.runCommandNoCC "${nameForDerivation}-boot" {
   } ''
     (
     mkdir -p $out
@@ -259,10 +259,10 @@ in
             Self-contained FIT image for the built kernel+initramfs.
           '';
         };
-        partitionContent = mkOption {
+        filesystemContent = mkOption {
           type = types.package;
           description = ''
-            Partition content such that the FIT image can be booted by the
+            Filesystem content such that the FIT image can be booted by the
             default boot process of U-Boot.
           '';
         };
@@ -275,7 +275,7 @@ in
       platform = u-bootPlatforms.${pkgs.targetPlatform.system};
       output = {
         fitImage = fitImage;
-        partitionContent = partitionContent;
+        inherit filesystemContent;
       };
     };
   };

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -266,6 +266,12 @@ in
             default boot process of U-Boot.
           '';
         };
+        filesystemImage = mkOption {
+          type = types.package;
+          description = ''
+            Filesystem image with the filesystemContent data.
+          '';
+        };
       };
     };
   };
@@ -276,6 +282,24 @@ in
       output = {
         fitImage = fitImage;
         inherit filesystemContent;
+        filesystemImage = (pkgs.celun.image-builder.evaluateFilesystemImage {
+          config =
+            { config, ... }:
+            let
+              inherit (config) helpers;
+            in
+            {
+              # TODO: make configurable by mkMerge'ing an attrset?
+              # TODO: make configurable by using an helper which provides a real deal submodule?
+              filesystem = "fat32";
+              extraPadding = helpers.size.MiB 1;
+              #label = "boot";
+              populateCommands = ''
+                cp -vt . ${filesystemContent}/*
+              '';
+            }
+          ;
+        }).config.output;
       };
     };
   };

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -220,6 +220,7 @@ let
     mkdir -p $out
     cp ${fitImage} $out/${nameForDerivation}.fit
     cp ${fitBootScript} $out/boot.scr
+    cp ${fitBootScript} $out/recovery.scr
     )
   '';
 

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -206,9 +206,11 @@ let
 
     echo -n ' :: Auto-booting FIT image'
      && setenv loadaddr $pxefile_addr_r
-     && echo -n ' -> Reading file'
+     && echo
+     && echo -n ' -> Reading file... '
      && load $devtype $devnum:$bootpart $loadaddr ${nameForDerivation}.fit
-     && echo -n ' -> Attempting boot...'
+     && echo
+     && echo -n ' -> Attempting boot... '
      && source $loadaddr:default-boot
   '');
 

--- a/modules/wip/uefi.nix
+++ b/modules/wip/uefi.nix
@@ -74,6 +74,7 @@ in
     wip.uefi = {
       platform = uefiPlatforms.${pkgs.targetPlatform.system};
     };
+    build.efiKernel = efiKernel;
     build.disk-image = (pkgs.celun.image-builder.evaluateDiskImage {
       config =
         { config, ... }:

--- a/pkgs/configurable-linux/default.nix
+++ b/pkgs/configurable-linux/default.nix
@@ -6,6 +6,7 @@
 , linuxManualConfig
 , runCommandNoCC
 
+, zlib
 , lz4
 , lzop
 , ...
@@ -132,6 +133,7 @@ linuxManualConfig rec {
 
   # FIXME: add lz4 / lzop only if compression requires it
   nativeBuildInputs = nativeBuildInputs ++ [
+    zlib
     lz4
     lzop
   ];


### PR DESCRIPTION
This is a bit of a mess of older commits.

These changes serve a few use-cases, and really should have been split in discrete PRs if this project was more active.

Changes:

 - Expose EFI kernel build to build outputs
 - Fix configurable linux build
 - Add RK3566 details
 - Misc. updates to U-Boot boot script