### PR TITLE
pkgs.nix: Update Nixpkgs pin

### DIFF
--- a/modules/wip/kernel.nix
+++ b/modules/wip/kernel.nix
@@ -132,7 +132,7 @@ in
       };
       package = mkOption {
         type = types.package;
-        default = pkgs.linux_5_13;
+        default = pkgs.linux_5_15;
         description = ''
           Base linux package to use.
 

--- a/modules/wip/u-boot.nix
+++ b/modules/wip/u-boot.nix
@@ -10,7 +10,7 @@ let
     mkMerge
     mkOption
     optionalString
-    replaceChars
+    replaceStrings
     types
   ;
   inherit (pkgs.stdenv.hostPlatform.linux-kernel) target;
@@ -25,7 +25,7 @@ let
     "/"
   ];
   replacementChars = map (_: "-") escapedNodeNameChars;
-  escapeNodeName = replaceChars escapedNodeNameChars replacementChars;
+  escapeNodeName = replaceStrings escapedNodeNameChars replacementChars;
 
   # Look-up table to translate from targetPlatform to U-Boot names.
   u-bootPlatforms = {

--- a/modules/wip/uefi.nix
+++ b/modules/wip/uefi.nix
@@ -35,7 +35,7 @@ let
       --add-section .cmdline="${kernelParamsFile}"          --change-section-vma  .cmdline=0x30000 \
       --add-section .linux="${kernel}/${target}"            --change-section-vma  .linux=0x2000000 \
       ${optionalString cfg.bundleInitramfs "--add-section .initrd='${initramfs}'                  --change-section-vma .initrd=0x3000000"} \
-      "${pkgs.libudev}/lib/systemd/boot/efi/linux${cfg.platform}.efi.stub" \
+      "${pkgs.systemd}/lib/systemd/boot/efi/linux${cfg.platform}.efi.stub" \
       "$out"
   '';
 in

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  rev = "5bc8b980b9178ef9a4bb622320cf34e59ea2ea10";
-  sha256 = "1zw8cigi50q6qac9nvb981p276bp5ap96sbdfgzrjf9m6210g6rk";
+  rev = "04f574a1c0fde90b51bf68198e2297ca4e7cccf4";
+  sha256 = "1frf2yspkgy72c5pznjgk8hbla7yyrn78azsf3ypkyb84vml5jnw";
 in
 import (
   builtins.fetchTarball {

--- a/pkgs/configurable-linux/default.nix
+++ b/pkgs/configurable-linux/default.nix
@@ -62,7 +62,7 @@ let
     EOF
   '';
 
-  allPatches = kernelPatches ++ (builtins.map (patch: { inherit patch; }) patches);
+  allPatches = (map (p: p.patch) kernelPatches) ++ patches;
 
   validatorSnippet = pkgs.writeShellScript "${name}-validator-snippet" ''
     ${evaluatedStructuredConfig.config.validatorSnippet}
@@ -78,7 +78,7 @@ linuxManualConfig rec {
   extraMakeFlags = [
     "KBUILD_BUILD_VERSION=1-celun"
   ];
-  kernelPatches = allPatches;
+  kernelPatches = [];
   inherit configfile;
 }
 ).overrideAttrs({ postPatch ? "", postInstall ? "" , nativeBuildInputs ? [], ... }: {
@@ -88,6 +88,10 @@ linuxManualConfig rec {
     ${validatorSnippet}
     )
   '';
+
+  # Ensure we don't inherit stray patches from the NixOS build harness...
+  # Because of the way we handle the kernel, they may be duplicated.
+  patches = allPatches;
 
   postPatch = postPatch +
   /* Logo patch from Mobile NixOS */

--- a/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , gptfdisk
 , buildPackages
-#, utillinux
+, utillinux
 , config
 }:
 
@@ -22,19 +22,6 @@ let
   inherit (config.gpt)
     hybridMBR
   ;
-
-  # Until we get 2.37 in Nixpkgs
-  patched-utillinux = buildPackages.utillinux.overrideAttrs({patches ? [], ...}: {
-    patches = patches ++ [
-      (fetchpatch {
-        # Same as the following commit, but for 2.36
-        # https://github.com/karelzak/util-linux/commit/60f2d1f0a7902b351195418f2116d7ea39a35369
-        url = "https://raw.githubusercontent.com/Tow-Boot/Tow-Boot/4a39ca8f6706d8262f0317f815cbcec587e1e0fa/support/image-builder/patches/0001-2.36-libfdisk-Include-table-length-in-first-lba-chec.patch";
-        sha256 = "1j4yndlblak4gq09hqmy6fxhh3b7qky102cl6ynjwrfz16ymqk67";
-      })
-    ];
-  });
-
 in
 stdenvNoCC.mkDerivation rec {
   inherit (config)
@@ -52,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     gptfdisk
-    patched-utillinux
+    utillinux
   ];
 
   buildCommand = let


### PR DESCRIPTION
All changes here are necessary for the update. This is over a year of "incompatibilities" and "breakage" from Nixpkgs changes.

The new pin is arbitrarily selected from whenever I started implementing the changes.