### PR TITLE
image-builder: Add squashfs support + improvements

### DIFF
--- a/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -160,7 +160,7 @@ stdenvNoCC.mkDerivation rec {
     echo
     echo "Writing partitions into image"
     ${each partitions (partition: 
-      if partition ? isGap && partition.isGap then
+      if !(partition ? raw && partition.raw != null) && partition ? isGap && partition.isGap then
         (gapFragment partition)
       else
         ''

--- a/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -124,7 +124,7 @@ stdenvNoCC.mkDerivation rec {
         (gapFragment partition)
       else
         ''
-          input_img="${partition.raw}"
+          input_img="${if partition.raw != null then partition.raw else ""}"
           ${sizeFragment partition}
           echo ' -> '${lib.escapeShellArg partition.name}": $size / ${if partition ? filesystemType then partition.filesystemType else ""}"
 
@@ -164,7 +164,10 @@ stdenvNoCC.mkDerivation rec {
         (gapFragment partition)
       else
         ''
-          input_img="${partition.raw}"
+          input_img="${if partition.raw != null then partition.raw else ""}"
+          if [[ "$input_img" == "" ]]; then
+            input_img="/dev/zero"
+          fi
           ${sizeFragment partition}
           echo ' -> '${lib.escapeShellArg partition.name}": $size / ${if partition ? filesystemType then partition.filesystemType else ""}"
 

--- a/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/pkgs/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation rec {
         offset=$((${toString partition.offset}))
 
         if (( offset < totalSize )); then
-          echo "Partition wanted to start at $offset while we were already at $totalSize"
+          echo "Partition '${partition.name}' wanted to start at $offset while we were already at $totalSize"
           echo "As of right now, partitions need to be in order."
           exit 1
         else

--- a/pkgs/image-builder/disk-image/partitions.nix
+++ b/pkgs/image-builder/disk-image/partitions.nix
@@ -109,8 +109,9 @@ let
       };
 
       raw = mkOption {
-        type = with types; oneOf [ package path ];
+        type = with types; nullOr (oneOf [ package path ]);
         defaultText = "[contents of the filesystem attribute]";
+        default = null;
         description = ''
           Raw image to be used as the partition content.
 

--- a/pkgs/image-builder/disk-image/partitions.nix
+++ b/pkgs/image-builder/disk-image/partitions.nix
@@ -87,10 +87,11 @@ let
       };
 
       filesystem = mkOption {
-        type = types.submodule ({
+        type = types.nullOr (types.submodule ({
           imports = import (../filesystem-image/module-list.nix);
           _module.args.pkgs = pkgs;
-        });
+        }));
+        default = null;
         description = ''
           A filesystem image configuration.
 
@@ -121,7 +122,7 @@ let
     };
 
     config = mkMerge [
-      (mkIf (!config.isGap) {
+      (mkIf (!config.isGap && config.filesystem != null) {
         raw = lib.mkDefault config.filesystem.output;
       })
     ];

--- a/pkgs/image-builder/filesystem-image/filesystem/default.nix
+++ b/pkgs/image-builder/filesystem-image/filesystem/default.nix
@@ -11,6 +11,7 @@ in
     ./btrfs.nix
     ./ext4.nix
     ./fat32.nix
+    ./squashfs.nix
   ];
 
   options = {

--- a/pkgs/image-builder/filesystem-image/filesystem/squashfs.nix
+++ b/pkgs/image-builder/filesystem-image/filesystem/squashfs.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+let
+  enabled = config.filesystem == "squashfs";
+  inherit (lib)
+    escapeShellArg
+    mkIf
+    mkMerge
+    mkOption
+    optionalString
+    types
+  ;
+
+  inherit (config) label sectorSize blockSize;
+  inherit (config.squashfs)
+    compression
+    compressionParams
+  ;
+in
+{
+  options.squashfs = {
+    compression = mkOption {
+      type = types.enum [
+        # Uses the name used in the -comp param
+        "gzip"
+        "xz"
+        "zstd"
+      ];
+      default = "xz";
+      description = ''
+        Volume ID of the filesystem.
+      '';
+    };
+    compressionParams = mkOption {
+      type = types.str;
+      internal = true;
+    };
+  };
+
+  config = mkMerge [
+    { availableFilesystems = [ "squashfs" ]; }
+    (mkIf enabled {
+      squashfs.compressionParams = mkMerge [
+        (mkIf (compression == "xz") "-Xdict-size 100%")
+        (mkIf (compression == "zstd") "-Xcompression-level 6")
+      ];
+
+      nativeBuildInputs = with pkgs.buildPackages; [
+        squashfsTools
+      ];
+
+      # NixOS's make-squashfs uses 1MiB
+      # mksquashfs's help says its default is 128KiB
+      blockSize = config.helpers.size.MiB 1;
+      # This is actually unused (and irrelevant)
+      sectorSize = lib.mkDefault 512;
+      minimumSize = 0;
+
+      computeMinimalSize = "";
+
+      buildPhases = {
+        copyPhase = ''
+          # The empty pre-allocated file will confuse mksquashfs
+          rm "$img"
+
+          (
+          # This also activates dotglob automatically.
+          # Using this means hidden files will be added too.
+          GLOBIGNORE=".:.."
+
+          # Using `.` as the input will put the PWD, including its name
+          # in the root of the filesystem.
+          mksquashfs \
+            * \
+            "$img" \
+            -info \
+            -b "$blockSize" \
+            -no-hardlinks -keep-as-directory -all-root \
+            -comp "${compression}" ${compressionParams} \
+            -processors $NIX_BUILD_CORES                                         
+          )
+        '';
+      };
+    })
+  ];
+}


### PR DESCRIPTION
These are changes accrued in a WIP project.

Adding squashfs support, while *more like an archive than a filesystem*, is useful since it allows using the same semantics for building squashfs images. My use-case is for the squashfs image to be either written on limited internal storage, or written into a filesystem. The latter allows replacing the rootfs in my particular use-case by simply replacing the `rootfs.img` file. This is also makes SD cards more usable by non-Linux users, as it exposes a single FAT32 partition to manipulate.

Adding a partition without data makes gaps work.

Gaps can now also be used with data. This may seem odd, but this is mainly used to fill the "unused" disk image space before the first partition without exposing a partition. This is a requirement for some use-case, even though *any firmware-like data should be exposed as a tangible partition*.

*  *  *

### Things done

 - Built TDM
 - Built all example systems