### PR TITLE
release-tools: Provide celunPath in arguments

### DIFF
--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -22,6 +22,9 @@ rec {
     )
   }: evalConfig {
     inherit baseModules;
+    specialArgs = {
+      celunPath = ../.;
+    };
     modules = []
       # `device` can be a couple of types.
       ++ (   if builtins.isAttrs device then [ device ]                    # An attrset is used directly


### PR DESCRIPTION
Expected use case: importing devices defined in celun in your other projects.

* * *

### Things done

In that other project, import and enhance qemu devices:

```nix
# devices/simulator/something-x86_64/default.nix
{ celunPath, config, lib, pkgs, ... }:

{
  imports = [
    (celunPath + "/devices/qemu/pc-x86_64")
  ];
# ...
}
```