### PR TITLE
Add modular kernel build

### DIFF
--- a/devices/qemu/raspi1ap-armv6l/default.nix
+++ b/devices/qemu/raspi1ap-armv6l/default.nix
@@ -1,5 +1,11 @@
 { config, lib, pkgs, ... }:
 
+let
+  inherit (lib)
+    head
+    splitString
+  ;
+in
 {
   device = {
     name = "qemu/raspi1ap-armv6l";
@@ -13,7 +19,12 @@
   # `Attempted to kill init! exitcode=0x0000000b`
   # wip.kernel.package = pkgs.linux_5_4;
   # See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977126
-  wip.kernel.package = pkgs.linux_4_19;
+  # NOTE: Using this weird `mkDerivation` here is a workaround to coax the
+  # `manual-config` builder to build :/
+  wip.kernel.package = pkgs.stdenv.mkDerivation {
+    inherit (pkgs.linux_4_19) src;
+    version = head (splitString "-" pkgs.linux_4_19.version);
+  };
   wip.kernel.defconfig = "bcm2835_defconfig";
   wip.kernel.structuredConfig =
     with lib.kernel;

--- a/modules/devices/qemu.nix
+++ b/modules/devices/qemu.nix
@@ -33,7 +33,11 @@ let
   inherit (stdenv) hostPlatform isAarch64 isx86_32 isx86_64;
   isx86 = isx86_32 || isx86_64;
   inherit (stdenv.hostPlatform) qemuArch;
-  inherit (stdenv.hostPlatform.linux-kernel) target;
+  target =
+    if stdenv.hostPlatform.linux-kernel.target == "uImage"
+    then "zImage" # We're not using uImage.
+    else stdenv.hostPlatform.linux-kernel.target
+  ;
   DTB = stdenv.hostPlatform.linux-kernel.DTB or false;
 
   kernel = config.wip.kernel.output;

--- a/modules/wip/kernel.nix
+++ b/modules/wip/kernel.nix
@@ -132,7 +132,7 @@ in
       };
       package = mkOption {
         type = types.package;
-        default = pkgs.linux_5_15;
+        default = pkgs.linux_5_15.overrideAttrs(_:{ postInstall = ""; });
         description = ''
           Base linux package to use.
 

--- a/modules/wip/kernel.nix
+++ b/modules/wip/kernel.nix
@@ -154,6 +154,13 @@ in
           Converted output for the Linux logo.
         '';
       };
+      isModular = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether kernel modules are built or not.
+        '';
+      };
       output = mkOption {
         type = types.package;
         internal = true;
@@ -183,7 +190,7 @@ in
         )
       '');
       kernel.output = pkgs.celun.configurableLinux {
-        inherit (config.wip.kernel) defconfig structuredConfig logoPPM;
+        inherit (config.wip.kernel) defconfig structuredConfig logoPPM isModular;
         inherit (config.wip.kernel.package) src version patches;
       };
 

--- a/modules/wip/kernel.nix
+++ b/modules/wip/kernel.nix
@@ -192,6 +192,7 @@ in
       kernel.output = pkgs.celun.configurableLinux {
         inherit (config.wip.kernel) defconfig structuredConfig logoPPM isModular;
         inherit (config.wip.kernel.package) src version patches;
+        postInstall = config.wip.kernel.package.postInstall or "";
       };
 
       # Sets up likely desired features

--- a/pkgs/configurable-linux/default.nix
+++ b/pkgs/configurable-linux/default.nix
@@ -20,6 +20,7 @@
 , kernelPatches ? []
 , defconfig
 , logoPPM ? null
+, isModular
 }:
 
 # Note:
@@ -85,7 +86,12 @@ linuxManualConfig rec {
     "KBUILD_BUILD_VERSION=1-celun"
   ];
   kernelPatches = [];
+  # TODO: normalize the config so that config works with allowImportFromDerivation
   inherit configfile;
+  config = {
+    # FIXME: use the normalized config so CONFIG_MODULES is used from actual config.
+    CONFIG_MODULES = if isModular then "y" else "n";
+  };
 }
 ).overrideAttrs({ postPatch ? "", postInstall ? "" , nativeBuildInputs ? [], ... }: {
   inherit target;
@@ -135,9 +141,13 @@ linuxManualConfig rec {
   extraMakeFlags = [ target ];
 
   postInstall = postInstall + ''
-    cp .config $out/config
+    (
+      cd $buildRoot
+      cp .config $out/config
+    )
 
     (
+      cd $buildRoot
       echo 'Built-ins:'
       echo '   text    data     bss     dec     hex filename'
       echo '================================================'

--- a/pkgs/configurable-linux/default.nix
+++ b/pkgs/configurable-linux/default.nix
@@ -16,6 +16,7 @@
 , version ? src.version
 , src
 , patches
+, postInstall ? ""
 , structuredConfig
 , kernelPatches ? []
 , defconfig
@@ -28,6 +29,7 @@
 # assumed way too much about the kernel that is going to be built :<
 
 let
+  postInstall' = postInstall;
   evaluatedStructuredConfig = import ./eval-config.nix {
     inherit (pkgs) path;
     inherit lib structuredConfig version;
@@ -154,6 +156,7 @@ linuxManualConfig rec {
       echo 
       size "$buildRoot"/*/built-in.o "$buildRoot"/*/built-in.a | sort -n -r -k 4
     ) > $out/built-ins.txt
+    ${postInstall'}
   '';
 
   # FIXME: add lz4 / lzop only if compression requires it


### PR DESCRIPTION
This mainly adds the semantics required for modular kernel builds to work. The semantics for making use of the modules in your config is not part of these changes.

Why is this needed? Working with a bad BSP kernel that won't build without modules support, but the modules built are not necessary. ¯\\\_(ツ)\_/¯

In addition, prefer `zImage` at all times rather than `uImage`. A Nixpkgs targets idiosyncracy.

* * *

### Things done

 - Built TDM
 - Built all examples system with hello