### PR TITLE
Add "block" feature for kernel config

### DIFF
--- a/devices/qemu/pc-x86_64/default.nix
+++ b/devices/qemu/pc-x86_64/default.nix
@@ -28,6 +28,12 @@
         DRM_FBDEV_EMULATION = yes;
         DRM_BOCHS = yes;
       })
+      (lib.mkIf (features.block) {
+        # Those might actually be needed :x
+        BLK_DEV_SD = yes;
+        ATA = yes;
+        ATA_PIIX = yes;
+      })
     ]
   ;
 }

--- a/devices/qemu/versatile-ARM9/default.nix
+++ b/devices/qemu/versatile-ARM9/default.nix
@@ -21,6 +21,14 @@
         VT_CONSOLE = yes;
         FRAMEBUFFER_CONSOLE = yes;
       }
+      (lib.mkIf (features.block) {
+        # For storage
+        PCI = yes;
+        PCI_VERSATILE = yes;
+        SCSI = yes;
+        SCSI_SYM53C8XX_2 = yes;
+        BLK_DEV_SD = yes;
+      })
       # TODO: disable/enable kernel config according to features.
     ]
   ;

--- a/devices/qemu/virt-aarch64/default.nix
+++ b/devices/qemu/virt-aarch64/default.nix
@@ -27,6 +27,12 @@
         PCI_HOST_GENERIC = yes;
         VIRTIO_INPUT = yes;
       })
+      (lib.mkIf (features.block) {
+        PCI = yes;
+        VIRTIO_MENU = yes;
+        VIRTIO_PCI = yes;
+        VIRTIO_BLK = yes;
+      })
     ]
   ;
 

--- a/modules/wip/kernel.nix
+++ b/modules/wip/kernel.nix
@@ -86,6 +86,12 @@ in
       BLK_DEV_INITRD = yes;
     })
 
+    (mkFeature "block" {
+      # Support for block devices
+      BLOCK = yes;
+      BLK_DEV = yes;
+    })
+
     (mkFeature "logo" {
       FB = yes;
       LOGO = yes;


### PR DESCRIPTION
This change set was required for another project to enable block devices in the simulator systems (qemu systems). The qemu systems [`imports`](https://github.com/celun/celun/pull/8) the qemu systems from celun, and add configuration to represent contrived equivalents to real hardware.

* * *

### Things done

 - built TDM
 - built example system


### Things to do

 - add example systems using the block feature to the celun examples