### PR TITLE
devices/qemu: Add armv7 and fixes

### DIFF
--- a/devices/qemu/versatile-ARM9/default.nix
+++ b/devices/qemu/versatile-ARM9/default.nix
@@ -29,7 +29,7 @@
     "mem=${toString config.device.config.qemu.memorySize}M"
   ];
   device.config.qemu = {
-    memorySize = 256;
+    memorySize = lib.mkDefault 256;
     qemuOptions = [
       "-machine versatilepb"
       ''-dtb "$self"/dtbs/versatile-pb.dtb''

--- a/devices/qemu/virt-armv7/default.nix
+++ b/devices/qemu/virt-armv7/default.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+{
+  device = {
+    name = "qemu/versatile-ARM9";
+    config.qemu.enable = true;
+  };
+
+  hardware = {
+    cpu = "generic-armv7l";
+  };
+  wip.kernel.defconfig = "multi_v7_defconfig";
+  wip.kernel.structuredConfig =
+    with lib.kernel;
+    let
+      inherit (config.wip.kernel) features;
+    in
+    lib.mkMerge [
+      ### TODO: disable/enable kernel config according to features.
+      (lib.mkIf (features.logo || features.vt || features.graphics) {
+        DRM = yes;
+        DRM_FBDEV_EMULATION = yes;
+        DRM_VIRTIO_GPU = yes;
+
+        # virtio gpu requires PCI
+        PCI = yes;
+        VIRTIO_MENU = yes;
+        VIRTIO_PCI = yes;
+        PCI_HOST_GENERIC = yes;
+        VIRTIO_INPUT = yes;
+      })
+      {
+        # No LPAE support in the virtual system.
+        ARM_LPAE = no;
+      }
+    ]
+  ;
+
+  boot.cmdline = [
+    "mem=${toString config.device.config.qemu.memorySize}M"
+  ];
+  device.config.qemu = {
+    memorySize = lib.mkDefault 128;
+    qemuOptions = [
+      # highmem=off is needed when LPAE is not enabled in the kernel
+      # As we're targeting "embedded" style targets, it makes sense
+      # to default to highmem off
+      # ref: https://bugs.launchpad.net/qemu/+bug/1790975/comments/3
+      # (See `ARM_LPAE = no`)
+      "-machine virt,highmem=off"
+      "-cpu cortex-a7"
+      "-device virtio-keyboard"
+      "-device virtio-tablet"
+      # Custom resolution could be added with:
+      #,xres=1366,yres=768
+      "-device virtio-gpu-pci"
+    ];
+  };
+}

--- a/modules/devices/qemu.nix
+++ b/modules/devices/qemu.nix
@@ -18,7 +18,9 @@ In turn, this should make using a docker container to build this output usable.
 
 let
   inherit (lib)
+    concatMapStringsSep
     concatStringsSep
+    escapeShellArg
     optional
     optionals
     optionalString
@@ -136,7 +138,7 @@ in
         self="''${BASH_SOURCE[0]%/*}"
 
         cmdline=(
-          ${concatStringsSep "\n" config.boot.cmdline}
+          ${concatMapStringsSep "\n  " escapeShellArg config.boot.cmdline}
         )
 
         args=(

--- a/modules/devices/qemu.nix
+++ b/modules/devices/qemu.nix
@@ -37,7 +37,7 @@ let
   DTB = stdenv.hostPlatform.linux-kernel.DTB or false;
 
   kernel = config.wip.kernel.output;
-  inherit (config.wip.stage-1.output) initramfs;
+  initramfs = config.build.initramfs or null;
 
   cfg = config.device.config.qemu;
 in
@@ -105,11 +105,12 @@ in
       qemuOptions = [
         "-m ${toString cfg.memorySize}"
         "-serial mon:stdio"
-      ] ++ optionals (cfg.bootMode == "direct") [
+      ] ++ optionals (cfg.bootMode == "direct") (
+        [
         "-kernel $self/${target}"
-        "-initrd $self/initramfs"
         ''-append "''${cmdline[*]}"''
-      ] ++ optionals (cfg.bootMode == "uefi") [
+        ] ++ (optional (initramfs != null) "-initrd $self/initramfs")
+      )++ optionals (cfg.bootMode == "uefi") [
         ''-bios  "$self/OVMF.fd"''
         ''-drive "file=$self/disk-image.img,format=raw,snapshot=on"''
       ] ++ optionals (cfg.bootMode == "drive") [

--- a/modules/devices/qemu.nix
+++ b/modules/devices/qemu.nix
@@ -142,14 +142,14 @@ in
         )
 
         args=(
-            # Always assume "bring your own QEMU".
-            # This makes it easier to run cross or native from a foreign arch.
-            # Also allows using the output on foreign systems without Nix.
-            qemu-system-${qemuArch}
+          # Always assume "bring your own QEMU".
+          # This makes it easier to run cross or native from a foreign arch.
+          # Also allows using the output on foreign systems without Nix.
+          qemu-system-${qemuArch}
 
-            ${concatStringsSep "\n" cfg.qemuOptions}
+          ${concatStringsSep "\n  " cfg.qemuOptions}
 
-            "$@"
+          "$@"
         )
 
         ${cfg.qemuAdditionalConfiguration}


### PR DESCRIPTION
These are fixes that ended-up being needed when working on a more complex project using celun.

In addition, while it probably should be its own PR, adds an armv7 qemu system.

* * *

### Things done

 - built TDM [no-op]
 - built example system for all systems