### PR TITLE
Add mips32 example system

### DIFF
--- a/devices/qemu/mips-32/default.nix
+++ b/devices/qemu/mips-32/default.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+{
+  device = {
+    name = "qemu/mips-32";
+    config.qemu.enable = true;
+  };
+
+  hardware = {
+    cpu = "generic-mips32";
+  };
+  wip.kernel.defconfig = "malta_defconfig";
+
+  device.config.qemu = {
+    qemuOptions = [
+      "-machine malta"
+    ];
+  };
+}

--- a/modules/celun/system.nix
+++ b/modules/celun/system.nix
@@ -7,7 +7,12 @@ let
   inherit (config.nixpkgs) localSystem;
 
   # The platform selected by the configuration
-  selectedPlatform = lib.systems.elaborate cfg.system;
+  selectedPlatform =
+    let
+      targetSystem = lib.systems.elaborate cfg.system;
+    in
+    targetSystem // { linux-kernel = { target = "vmlinuz"; } // targetSystem.linux-kernel; }
+  ;
 in
 {
   options.celun = {
@@ -31,6 +36,7 @@ in
           "armv6l-linux"
           "armv7l-linux"
           "aarch64-linux"
+          "mipsel-linux"
         ];
         description = ''
           Defines the kind of target architecture system the device is.

--- a/modules/hardware/cpus/generic.nix
+++ b/modules/hardware/cpus/generic.nix
@@ -45,6 +45,12 @@ in
       description = "Enable when system is a generic armv7l";
       internal = true;
     };
+    generic-mips32.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable when system is a generic MIPS 32-bit";
+      internal = true;
+    };
   };
 
   config = {
@@ -55,6 +61,7 @@ in
       (lib.mkIf cfg.generic-armv6l.enable "armv6l-linux")
       (lib.mkIf cfg.generic-armv7l.enable "armv7l-linux")
       (lib.mkIf cfg.generic-aarch64.enable "aarch64-linux")
+      (lib.mkIf cfg.generic-mips32.enable "mipsel-linux")
     ];
   };
 }

--- a/pkgs/configurable-linux/default.nix
+++ b/pkgs/configurable-linux/default.nix
@@ -156,6 +156,20 @@ linuxManualConfig rec {
       echo 
       size "$buildRoot"/*/built-in.o "$buildRoot"/*/built-in.a | sort -n -r -k 4
     ) > $out/built-ins.txt
+    ${lib.optionalString (target == "vmlinuz" || target == "vmlinux") ''
+      (
+      cd $out
+      # See arch/mips/Makefile, installed file includes version number.
+      # Attempting to move both since installing the compressed version
+      # installs the uncompressed version.
+      if [ -e vmlinux-* ]; then
+        mv -v vmlinux-* vmlinux
+      fi
+      if [ -e vmlinuz-* ]; then
+        mv -v vmlinuz-* vmlinuz
+      fi
+      )
+    ''}
     ${postInstall'}
   '';
 


### PR DESCRIPTION
This builds on top of #9, so drafted/blocked until that one is reviewed and merged.

Not that this requires anything from #9, but that it would anyway require resolving an already resolved merge conflict.

* * *

This adds basic support for MIPS 32 bit (R2) systems.

This is only supported through a qemu system, but so is most other systems at this time.

This will be used by *that other WIP project* to support graphical MIPS-based systems.